### PR TITLE
Don't trigger any switches if there is only one URL in the list

### DIFF
--- a/scripts/switcher.sh
+++ b/scripts/switcher.sh
@@ -6,16 +6,18 @@ export XDG_RUNTIME_DIR=/run/user/1000
 # count the number of URLs, that are configured to cycle through
 URLS=$(jq -r '.urls | length' ~/piosk/config.json)
 
-# swich tabs each 10s, refresh tabs each 10th cycle & then reset
-for ((TURN=1; TURN<=$((10*URLS)); TURN++)) do
-  if [ $TURN -le $((10*URLS)) ]; then
-    wtype -M ctrl -P Tab
-    if [ $TURN -gt $((9*URLS)) ]; then
-      wtype -M ctrl r
-      if [ $TURN -eq $((10*URLS)) ]; then
-        (( TURN=0 ))
+if [ $URLS -gt 1 ]; then
+  # swich tabs each 10s, refresh tabs each 10th cycle & then reset
+  for ((TURN=1; TURN<=$((10*URLS)); TURN++)) do
+    if [ $TURN -le $((10*URLS)) ]; then
+      wtype -M ctrl -P Tab
+      if [ $TURN -gt $((9*URLS)) ]; then
+        wtype -M ctrl r
+        if [ $TURN -eq $((10*URLS)) ]; then
+          (( TURN=0 ))
+        fi
       fi
     fi
-  fi
-  sleep 10
-done
+    sleep 10
+  done
+fi


### PR DESCRIPTION
This prevents some sites (e.g. HomeAssistant dashboards) from reloading or refreshing repeatedly.