### PR TITLE
Advanced chromium control -> No more keyboard shortcut emulation

### DIFF
--- a/scripts/chromium-next-tab.sh
+++ b/scripts/chromium-next-tab.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Chromium remote debugging port (default: 9222)
+DEBUG_PORT=9222
+
+# Get the list of open tabs in JSON format
+tabs_json=$(curl -s http://localhost:$DEBUG_PORT/json)
+
+# Index of the currently focused tab (assumed to be the first)
+focused_index=0
+
+# Total number of tabs
+total_tabs=$(echo "$tabs_json" | jq 'length')
+
+# Calculate next index (wrap around if at the end)
+#next_index=$(( (focused_index + 1) % total_tabs ))
+next_index=$(( (total_tabs - 1) % total_tabs )) # The last json object seems to be the next tab
+
+# Extract the ID of the next tab
+next_tab_id=$(echo "$tabs_json" | jq -r ".[$next_index].id")
+next_tab_title=$(echo "$tabs_json" | jq -r ".[$next_index].title")
+next_tab_url=$(echo "$tabs_json" | jq -r ".[$next_index].url")
+
+# Occasionally there appears to be created a new empty and unusable tab. Not sure why.
+# We tried to remove that tab when that happend, but was unsuccessfull.
+# So now we just skip that tab when that happens:
+if [ -z "$next_tab_url" ] || [ "$next_tab_url" = "about:blank" ]; then
+    echo "Tab [$next_index] [$next_tab_id] is empty, falling back to second-last"
+    next_index=$(( next_index - 1 ))
+    next_tab_id=$(echo "$tabs_json" | jq -r ".[$next_index].id")
+    next_tab_title=$(echo "$tabs_json" | jq -r ".[$next_index].title")
+    next_tab_url=$(echo "$tabs_json" | jq -r ".[$next_index].url")
+fi
+
+# Activate the next tab
+curl -s "http://localhost:$DEBUG_PORT/json/activate/$next_tab_id" > /dev/null
+echo "Switched to tab [$next_index]: $next_tab_title ($next_tab_url | $next_tab_id) (total of $total_tabs)"

--- a/scripts/chromium-reload-tab.py
+++ b/scripts/chromium-reload-tab.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# This is done in Python because doing websocket comms in bash is a pain in the ...
+# Needs: "sudo apt install python3-websockets" to work
+import asyncio
+import websockets
+import json
+import subprocess
+
+# Get the WebSocket URL for the first tab
+debug_info = subprocess.check_output(["curl", "-s", "http://localhost:9222/json"])
+tabs = json.loads(debug_info)
+ws_url = tabs[0]["webSocketDebuggerUrl"]
+
+# Send reload command
+async def reload_tab():
+    async with websockets.connect(ws_url) as ws:
+        await ws.send(json.dumps({
+            "id": 1,
+            "method": "Page.reload",
+            "params": {"ignoreCache": False}
+        }))
+        response = await ws.recv()
+        print("Reloaded tab:", response)
+
+asyncio.run(reload_tab())

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -16,4 +16,5 @@ chromium-browser \
   --ignore-gpu-blocklist \
   --kiosk \
   --no-first-run \
-  --noerrdialogs
+  --noerrdialogs \
+  --remote-debugging-port=9222

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,7 +35,7 @@ else
 fi
 
 echo -e "${INFO}Installing dependencies...${RESET}"
-apt install -y git jq wtype nodejs npm
+apt install -y git jq wtype nodejs npm python3-websockets
 
 echo -e "${INFO}Cloning repository...${RESET}"
 git clone https://github.com/debloper/piosk.git "$PIOSK_DIR"

--- a/scripts/switcher.sh
+++ b/scripts/switcher.sh
@@ -12,9 +12,9 @@ URLS=$(jq -r '.urls | length' /opt/piosk/config.json)
 # swich tabs each 10s, refresh tabs each 10th cycle & then reset
 for ((TURN=1; TURN<=$((10*URLS)); TURN++)) do
   if [ $TURN -le $((10*URLS)) ]; then
-    wtype -M ctrl -P Tab
+    /opt/piosk/scripts/chromium-next-tab.sh
     if [ $TURN -gt $((9*URLS)) ]; then
-      wtype -M ctrl r
+      /opt/piosk/scripts/chromium-reload-tab.py
       if [ $TURN -eq $((10*URLS)) ]; then
         (( TURN=0 ))
       fi


### PR DESCRIPTION
I've had more than once that Chromium can lose keyboard input focus due to:
- Disconnecting or turning off the HDMI monitor/tv
- Connecting/disconnecting with VNC
- Popup of a notification from the taskbar
- At random after startup no keyboard input focus

This causes the kiosk mode to just get stuck on whatever page is showing until you Alt+Tab to it or click it to give it focus.

I've tried to implement various ways of making sure keyboard input focus stays at Chromium, so that Ctrl+Tab and Ctrl+R keep on working, regardless of what happens with the Raspberry GUI. Only to find out its all just not good enough or a nice solid, maintainable, understandable solution.

The only nice, proper and rocksolid solution I could think of was to completely abandon the keyboard shortcut usage. For that I implemented the use of the Chromium debugging port, via that port Chromium can be controlled in many different ways and more importantly: It doesn't matter if it has or hasn't keyboard input focus, because we're not using keyboard shortcuts anymore.

This results in a always working tab-switch. Even when Chromium is not having keyboard input focus. I think this will be a great change for this project as I can imagine that many people have this problem with their "PiOSK" that suddenly stops changing tabs.

A couple of remarks about this change:
- You'll see that one of my new files (chromium-reload-tab.py)  is a Python file, this is due to this reload function needed a websocket connection and doing that in bash, wasn't my thing. It posed too many things that needed a change, so I figured using Python was the better way.
- In a seperate commit I've removed the `--enable-low-end-device-mode` option from Chromium, as with that option the color depth was decreased significantly, making any picture look horrible. Tested on a Raspberry Pi 4b, looked good after that. Feel free to ignore this change.