### PR TITLE
fix(action): explicitly add package-manager for astro

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -23,6 +23,7 @@ jobs:
         uses: withastro/action@v4
         with:
           path: www
+          package-manager: npm
 
   deploy:
     name: Deploy


### PR DESCRIPTION
https://github.com/debloper/piosk/actions/runs/16654165831/job/47134671674

```
Run withastro/action@v4
Run len=`echo $INPUT_PM | wc -c`
No lockfile found.
Please specify your preferred "package-manager" in the action configuration.
Error: Process completed with exit code 1.
```