### PR TITLE
feat: Implement per-URL duration and refresh cycle configuration

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -1,25 +1,39 @@
 {
-    "urls": [
-        {
-            "url": "https://windy.com/"
-        },
-        {
-            "url": "https://time.is/clock"
-        },
-        {
-            "url": "https://github.com/trending"
-        },
-        {
-            "url": "https://news.ycombinator.com/"
-        },
-        {
-            "url": "https://huggingface.co/papers"
-        },
-        {
-            "url": "https://www.perplexity.ai/discover"
-        },
-        {
-            "url": "https://www.google.com/search?q=nasdaq+index"
-        }
-    ]
+  "urls": [
+    {
+      "url": "https://windy.com/",
+      "duration": 10,
+      "cycles": 10
+    },
+    {
+      "url": "https://time.is/clock",
+      "duration": 10,
+      "cycles": 10
+    },
+    {
+      "url": "https://github.com/trending",
+      "duration": 10,
+      "cycles": 10
+    },
+    {
+      "url": "https://news.ycombinator.com/",
+      "duration": 10,
+      "cycles": 10
+    },
+    {
+      "url": "https://huggingface.co/papers",
+      "duration": 10,
+      "cycles": 10
+    },
+    {
+      "url": "https://www.perplexity.ai/discover",
+      "duration": 10,
+      "cycles": 10
+    },
+    {
+      "url": "https://www.google.com/search?q=nasdaq+index",
+      "duration": 10,
+      "cycles": 10
+    }
+  ]
 }

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -11,7 +11,6 @@ chromium-browser \
   --disable-smooth-scrolling \
   --enable-accelerated-video-decode \
   --enable-gpu-rasterization \
-  --enable-low-end-device-mode \
   --enable-oop-rasterization \
   --force-device-scale-factor=1 \
   --ignore-gpu-blocklist \

--- a/scripts/switcher.sh
+++ b/scripts/switcher.sh
@@ -1,24 +1,74 @@
 #!/bin/bash
 
-# @TODO: fetch the user dynamically or from config
+# Ensure the script runs from the correct directory, where config.json is located.
+cd /opt/piosk
+
 export XDG_RUNTIME_DIR=/run/user/1000
 
-# THIS IS NOT THE BEST WAY TO SWITCH & REFRESH TABS BUT IT WORKS
-# should parameterize cycle count & sleep delay with config.json
+# --- Read Configuration using jq ---
+# Create a Bash array of durations for each URL.
+mapfile -t DURATIONS < <(jq -r '.urls[].duration' ./config.json)
 
-# count the number of URLs, that are configured to cycle through
-URLS=$(jq -r '.urls | length' /opt/piosk/config.json)
+# Create a Bash array of cycle counts before a refresh is triggered.
+mapfile -t CYCLES < <(jq -r '.urls[].cycles' ./config.json)
 
-# swich tabs each 10s, refresh tabs each 10th cycle & then reset
-for ((TURN=1; TURN<=$((10*URLS)); TURN++)) do
-  if [ $TURN -le $((10*URLS)) ]; then
-    wtype -M ctrl -P Tab
-    if [ $TURN -gt $((9*URLS)) ]; then
-      wtype -M ctrl r
-      if [ $TURN -eq $((10*URLS)) ]; then
-        (( TURN=0 ))
-      fi
-    fi
+# Count the total number of URLs to manage.
+URL_COUNT=${#DURATIONS[@]}
+
+# If no URLs are configured, exit gracefully.
+if [ "$URL_COUNT" -eq 0 ]; then
+  echo "No URLs configured. Exiting switcher."
+  exit 0
+fi
+
+# --- Initialize State ---
+# Create and initialize an array to track the display count for each tab.
+REFRESH_COUNTS=()
+for ((i=0; i<URL_COUNT; i++)); do
+  REFRESH_COUNTS+=(0)
+done
+
+CURRENT_TAB_INDEX=0
+
+# Give Chromium a moment to start up on boot before we start sending keys.
+echo "Switcher waiting for browser to initialize..."
+sleep 15
+
+echo "PiOSK switcher started. Managing $URL_COUNT tabs."
+
+# --- Main Loop ---
+while true; do
+  # --- Get Settings for the Current Tab ---
+  duration=${DURATIONS[$CURRENT_TAB_INDEX]}
+  cycle_target=${CYCLES[$CURRENT_TAB_INDEX]}
+
+  # --- Handle Refresh Logic ---
+  # Increment the display counter for the current tab.
+  ((REFRESH_COUNTS[$CURRENT_TAB_INDEX]++))
+  echo "Tab $((CURRENT_TAB_INDEX + 1)): Display cycle ${REFRESH_COUNTS[$CURRENT_TAB_INDEX]} of $cycle_target."
+
+  # Check if it's time to refresh this specific tab.
+  if [ "${REFRESH_COUNTS[$CURRENT_TAB_INDEX]}" -ge "$cycle_target" ]; then
+    echo "Refreshing Tab $((CURRENT_TAB_INDEX + 1))."
+    
+    # Send Ctrl+r to refresh the current tab using wtype.
+    wtype -M ctrl r -m ctrl
+    
+    # Reset the counter for this tab.
+    REFRESH_COUNTS[$CURRENT_TAB_INDEX]=0
   fi
-  sleep 10
+  
+  # --- Wait for the specified duration ---
+  echo "Waiting for $duration seconds."
+  sleep "$duration"
+
+  # --- Switch to the Next Tab ---
+  echo "Switching to next tab."
+  # Send Ctrl+Tab to switch to the next tab using wtype.
+  wtype -M ctrl -P Tab -m ctrl
+
+  # --- Update Tab Index ---
+  # Move to the next index, wrapping around to 0 if at the end.
+  CURRENT_TAB_INDEX=$(( (CURRENT_TAB_INDEX + 1) % URL_COUNT ))
+
 done

--- a/web/index.html
+++ b/web/index.html
@@ -7,13 +7,26 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 
     <title>PiOSK</title>
+    <style>
+      .input-changed {
+        background-color: rgba(255, 193, 7, 0.2) !important;
+        border-color: #ffc107 !important;
+        box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.25) !important;
+        transition: all 0.3s ease;
+      }
+      .input-changed:focus {
+        background-color: rgba(255, 193, 7, 0.3) !important;
+        border-color: #ffc107 !important;
+        box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5) !important;
+      }
+    </style>
   </head>
   <body>
     <nav id="navs" class="navbar bg-body-tertiary">
       <div class="container-md d-flex justify-content-between">
         <h1 class="my-1">Pi<span class="bg-danger mx-1 px-1 rounded">OSK</span></h1>
         <div class="input-group w-75">
-          <input  id="new-url" type="text"   class="form-control form-control-lg" placeholder="...add URLs of webpages as screens">
+          <input  id="new-url" type="text" class="form-control form-control-lg" placeholder="...add URLs of webpages as screens">
           <button id="add-url" type="button" class="btn btn-secondary">ADD</button>
           <button id="execute" type="button" class="btn btn-danger">APPLY <span class="align-text-bottom">⏻</span></button>
         </div>
@@ -33,9 +46,24 @@
     </footer>
 
     <template id="template-url">
-      <li class="list-group-item text-truncate fs-3">
-        <button type="button" class="btn btn-close mx-3" aria-label="Remove"></button>
-        <a class="link-underline-dark"></a>
+      <li class="list-group-item fs-3">
+        <div class="d-flex justify-content-between align-items-center">
+          <div class="d-flex align-items-center flex-grow-1">
+            <button type="button" class="btn btn-close mx-3" aria-label="Remove"></button>
+            <a class="link-underline-dark text-truncate"></a>
+          </div>
+          <div class="d-flex align-items-center gap-2 ms-3">
+            <div class="input-group input-group-sm" style="width: 150px;">
+              <span class="input-group-text">Duration</span>
+              <input type="number" class="form-control duration-input" min="1" max="300" value="10">
+              <span class="input-group-text">s</span>
+            </div>
+            <div class="input-group input-group-sm" style="width: 120px;">
+              <span class="input-group-text">Cycles</span>
+              <input type="number" class="form-control cycles-input" min="1" max="100" value="10">
+            </div>
+          </div>
+        </div>
       </li>
     </template>
 
@@ -45,6 +73,22 @@
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+
+    <script>
+      $(document).ready(function() {
+        // Use event delegation to highlight inputs when they are changed.
+        $('#urls').on('change', '.duration-input, .cycles-input', function() {
+          $(this).addClass('input-changed');
+        });
+
+        // Add a separate click listener to the Apply button just to remove the highlight.
+        // This will fire alongside the listener in script.js that saves the data.
+        $('#execute').on('click', function() {
+          $('.input-changed').removeClass('input-changed');
+        });
+      });
+    </script>
+
     <script src="script.js"></script>
   </body>
 </html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,48 +1,76 @@
 let piosk = {
-  addNewUrl () {
-    let newUrl = $('#new-url').val()
-    if (!newUrl) return
+  addNewUrl() {
+    let newUrl = $('#new-url').val();
+    if (!newUrl) return;
 
-    piosk.appendUrl(newUrl)
-    $('#new-url').val('')
+    // Call appendUrl with just the URL, so it uses default settings (10s, 10 cycles)
+    piosk.appendUrl(newUrl); 
+    $('#new-url').val('');
   },
-  appendUrl (url) {
-    let tmpUrl = $('#template-url').contents().clone()
 
-    $(tmpUrl).find('a').attr('href', url).html(url)
-    $('#urls .list-group').append(tmpUrl)
+  // MODIFIED: Now accepts duration and cycles as arguments
+  appendUrl(url, duration, cycles) {
+    let tmpUrl = $('#template-url').contents().clone();
+
+    $(tmpUrl).find('a').attr('href', url).html(url);
+
+    // If duration and cycles are provided from config, set them.
+    if (duration) {
+      $(tmpUrl).find('.duration-input').val(duration);
+    }
+    if (cycles) {
+      $(tmpUrl).find('.cycles-input').val(cycles);
+    }
+
+    $('#urls .list-group').append(tmpUrl);
   },
-  renderPage (data) {
-    $.each(data.urls, (index, item) => {
-      piosk.appendUrl(item.url)
-    })
+
+  // MODIFIED: Now passes the full item data to appendUrl
+  renderPage(data) {
+    if (data && data.urls) {
+      $.each(data.urls, (index, item) => {
+        // Pass all the data (url, duration, cycles) to the updated function
+        piosk.appendUrl(item.url, item.duration, item.cycles);
+      });
+    }
   },
-  showStatus (xhr) {
-    let tmpErr = $('#template-err').contents().clone()
-    tmpErr.html(xhr.responseText)
-    $('#urls').append(tmpErr)
-    setTimeout(_ => { $('.alert-danger').remove() }, 5000)
+
+  showStatus(xhr) {
+    let tmpErr = $('#template-err').contents().clone();
+    tmpErr.html(xhr.responseText);
+    $('#urls').append(tmpErr);
+    setTimeout(_ => { $('.alert-danger').remove() }, 5000);
   }
-}
+};
 
 $(document).ready(() => {
   $.getJSON('/config')
-  .done(piosk.renderPage)
-  .fail(piosk.showStatus)
+    .done(piosk.renderPage)
+    .fail(piosk.showStatus);
 
-  $('#add-url').on('click', piosk.addNewUrl)
-  $('#new-url').on('keyup', (e) => { if (e.key === 'Enter') piosk.addNewUrl() })
+  $('#add-url').on('click', piosk.addNewUrl);
+  $('#new-url').on('keyup', (e) => { if (e.key === 'Enter') piosk.addNewUrl(); });
 
   $('#urls').on('click', 'button.btn-close', (e) => {
-    $(e.target).parent().remove()
-  })
+    $(e.target).closest('li.list-group-item').remove();
+  });
 
+  // MODIFIED: The #execute handler now saves all settings correctly
   $('#execute').on('click', (e) => {
-    let config = {}
-    config.urls = []
+    let config = {};
+    config.urls = [];
     $('li.list-group-item').each((index, item) => {
-      config.urls.push({ url: $(item).find('a').attr('href') })
-    })
+      // Now collecting all data: url, duration, and cycles
+      const url = $(item).find('a').attr('href');
+      const duration = parseInt($(item).find('.duration-input').val()) || 10;
+      const cycles = parseInt($(item).find('.cycles-input').val()) || 10;
+
+      config.urls.push({
+        url: url,
+        duration: duration,
+        cycles: cycles
+      });
+    });
 
     $.ajax({
       url: '/config',
@@ -52,6 +80,6 @@ $(document).ready(() => {
       dataType: "json",
       success: piosk.showStatus,
       error: piosk.showStatus
-    })
-  })
-})
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces a major enhancement to PiOSK, moving from a hardcoded display configuration for all URLs to a flexible, per-URL parameter system. 
Users can now define a specific display `duration` and a `refresh cycle` count for each individual URL in the dashboard.

<img width="1854" height="1081" alt="image" src="https://github.com/user-attachments/assets/dbc503ef-877f-4227-8d25-89c674032bcc" />


Changes to duration or cycle values are highlighted until they are applied

<img width="1854" height="1081" alt="image" src="https://github.com/user-attachments/assets/89ba424f-a136-4b5d-9db9-37543aadd9ba" />

