### PR TITLE
Fix: Ensure reboot works reliably

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,11 +25,10 @@ async function rebootSystem(): Promise<void> {
     }
     
     // Use absolute path to the reboot command
-    const command = new Deno.Command("/sbin/reboot", {
-      stdout: "piped",
-      stderr: "piped"
-    });
-    await command.output();
+    const command = new Deno.Command("/sbin/reboot"); 
+
+    // Spawn the process to run in the background and DO NOT await it. 
+    command.spawn();
   } catch (error) {
     console.error("Reboot command failed:", error);
     throw error;

--- a/index.ts
+++ b/index.ts
@@ -24,7 +24,8 @@ async function rebootSystem(): Promise<void> {
       return;
     }
     
-    const command = new Deno.Command("reboot", {
+    // Use absolute path to the reboot command
+    const command = new Deno.Command("/sbin/reboot", {
       stdout: "piped",
       stderr: "piped"
     });

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# export essential GUI variables for systemd services
+export DISPLAY=:0
+export XDG_RUNTIME_DIR=/run/user/$(id -u)
+
+# give the desktop a moment to settle
+sleep 5
+
+# check to ensure URLs are there to load
+URLS_TO_LOAD=$(jq -r '.urls | map(.url) | join(" ")' /opt/piosk/config.json)
+if [ -z "$URLS_TO_LOAD" ]; then
+    echo "No URLs found in config.json. Exiting runner."
+    exit 0
+fi
+
 chromium-browser \
   $(jq -r '.urls | map(.url) | join(" ")' /opt/piosk/config.json) \
   --disable-component-update \

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -8,14 +8,14 @@ export XDG_RUNTIME_DIR=/run/user/$(id -u)
 sleep 5
 
 # check to ensure URLs are there to load
-URLS_TO_LOAD=$(jq -r '.urls | map(.url) | join(" ")' /opt/piosk/config.json)
-if [ -z "$URLS_TO_LOAD" ]; then
+URLS=$(jq -r '.urls | map(.url) | join(" ")' /opt/piosk/config.json)
+if [ -z "$URLS" ]; then
     echo "No URLs found in config.json. Exiting runner."
     exit 0
 fi
 
 chromium-browser \
-  $(jq -r '.urls | map(.url) | join(" ")' /opt/piosk/config.json) \
+  $URLS \
   --disable-component-update \
   --disable-composited-antialiasing \
   --disable-gpu-driver-bug-workarounds \


### PR DESCRIPTION
This PR fixes a critical bug that prevented the kiosk mode from launching correctly after applying settings from the dashboard.

**Problem:**
After applying settings from the dashboard, the Pi would reboot and get stuck on the Raspberry Pi logo splash screen, never launching the desktop or Chromium.

**Solution:**
`runner.sh`: 
- Export `DISPLAY=:0` and `XDG_RUNTIME_DIR=/run/user/$(id -u)` to provide the necessary graphical context.
- Add a guard clause to check if any URLs exist in the config, preventing Chromium from launching without URLs and allowing the script to exit gracefully.

`index.ts`:
- The `rebootSystem` function is modified to use the absolute path `/sbin/reboot`
- This is a universal and unambiguous path that does not depend on the PATH variable, ensuring the command works reliably in the systemd service environment.
