### PR TITLE
Release/version 4: Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,13 @@ sudo /opt/piosk/scripts/cleanup.sh
 ## 2.1 Assumptions
 
 0. You're using a Raspberry Pi (other SBCs may work, not tested)
-1. You're using "[Raspberry Pi OS (64bit)](https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-64-bit)" (This is a mandatory requirement for PiOSK (version 4.0.0 and newer). PiOSK now uses the Deno runtime, which does not provide official binaries for 32-bit ARM systems. This change allows PiOSK to be a standalone executable, simplifying installation by removing the need for a separate Node.js runtime.)
+1. You're using "[Raspberry Pi OS (64bit)](https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-64-bit)" (required for PiOSK 4.0.0+)
 2. You've applied proper [OS customizations](https://www.raspberrypi.com/documentation/computers/getting-started.html#advanced-options) & the Pi is able to access the internet (required for setup)
 3. You're not using port 80 on the Pi to run some other web server (apart from PiOSK dashboard)
 
+> [!NOTE]
+> **Why 64-bit OS is required:**  
+> PiOSK (version 4.0.0 and newer) now uses the Deno runtime, which does not provide official binaries for 32-bit ARM systems. This change allows PiOSK to be a standalone executable, simplifying installation by removing the need for a separate Node.js runtime.
 ## 2.2 Recommendations
 
 - Choose the right device and OS

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ That's when I realized... maybe there are other people (or future me) who'd also
 Either open terminal on the Raspberry Pi's desktop environment, or remote login to it; and run the following command:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/debloper/piosk/45397876cf82a8113da55e84aa3c8da74a1ef5df/scripts/setup.sh | sudo bash -
+curl -sSL https://raw.githubusercontent.com/debloper/piosk/v4.0.0/scripts/setup.sh | sudo bash -
 ```
 
 That's it[^2].

--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ That's it[^2].
 
 1. The PiOSK repo is cloned to `/opt/piosk`
 2. You can change the dashboard port by setting the `PORT` from `index.js`
-3. You can change the per-page timeout from `scripts/switcher.sh`
-4. You can change browser behavior (e.g. no full screen) from `scripts/runner.sh`
-5. Some changes can be applied without rebooting, but rebooting is simpler
+3. You can change browser behavior (e.g. no full screen) from `scripts/runner.sh`
+4. Some changes can be applied without rebooting, but rebooting is simpler
 
 [^3]: PiOSK uses port 80 on the Pi to serve the web dashboard. If you're planning to use the Pi for other purposes, make sure to avoid port collision.
 
@@ -91,21 +90,20 @@ sudo /opt/piosk/scripts/cleanup.sh
 ```
 
 > [!NOTE]  
-> By default PiOSK doesn't uninstall the system packages it installs as dependencies (i.e. `git`, `jq`, `Node.js`, `wtype`). The reason being, if they're force removed, then other packages (which have been installed since) that may also rely on them - will break.
+> By default PiOSK doesn't uninstall the system packages it installs as dependencies (i.e. `git`, `jq`, `wtype`). The reason being, if they're force removed, then other packages (which have been installed since) that may also rely on them - will break.
 
 # 2. Appendix
 
 ## 2.1 Assumptions
 
 0. You're using a Raspberry Pi (other SBCs may work, not tested)
-1. You're using "[Raspberry Pi OS with desktop (32bit)](https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-32-bit)" (other distros may work, not tested)
+1. You're using "[Raspberry Pi OS (64bit)](https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-64-bit)" (This is a mandatory requirement for PiOSK (version 4.0.0 and newer). PiOSK now uses the Deno runtime, which does not provide official binaries for 32-bit ARM systems. This change allows PiOSK to be a standalone executable, simplifying installation by removing the need for a separate Node.js runtime.)
 2. You've applied proper [OS customizations](https://www.raspberrypi.com/documentation/computers/getting-started.html#advanced-options) & the Pi is able to access the internet (required for setup)
 3. You're not using port 80 on the Pi to run some other web server (apart from PiOSK dashboard)
 
 ## 2.2 Recommendations
 
 - Choose the right device and OS
-  - If your Pi has 4GB or less memory, choose 32bit image
   - Raspberry Pi Zeros struggle running Chromium due to low memory
   - Raspberry Pi4 or Pi5 (or their compute modules) are ideal for PiOSK
   - Apply the necessary customizations (user account, WiFi credentials, SSH access etc)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -44,7 +44,19 @@ fi
 echo -e "${INFO}Installing dependencies...${RESET}"
 apt update && apt install -y git jq wtype curl unzip
 
-# --- Repo Cloning ---
+# --- Get Latest Release Info ---
+# Fetched early to be used for both git checkout and binary download.
+echo -e "${INFO}Finding latest stable release...${RESET}"
+LATEST_RELEASE=$(curl -s https://api.github.com/repos/debloper/piosk/releases/latest | jq -r '.tag_name')
+
+if [ -z "$LATEST_RELEASE" ] || [ "$LATEST_RELEASE" = "null" ]; then
+  echo -e "${ERROR}Could not find any releases on the GitHub repository.${RESET}"
+  exit 1
+fi
+echo -e "${SUCCESS}Latest release is ${LATEST_RELEASE}.${RESET}"
+
+
+# --- Repo Cloning and Checkout ---
 echo -e "${INFO}Cloning repository...${RESET}"
 
 # Before deleting the directory, check if a config file exists and back it up.
@@ -56,6 +68,10 @@ fi
 rm -rf "$PIOSK_DIR"
 git clone https://github.com/debloper/piosk.git "$PIOSK_DIR"
 cd "$PIOSK_DIR"
+
+# Checkout the latest stable release to ensure code matches the binary
+echo -e "${INFO}Checking out release ${LATEST_RELEASE}...${RESET}"
+git checkout "$LATEST_RELEASE"
 
 # --- Binary Download ---
 echo -e "${INFO}Downloading PiOSK binary...${RESET}"
@@ -78,12 +94,6 @@ esac
 
 echo -e "${DEBUG}Architecture: '$ARCH', Binary: '$BINARY_NAME'${RESET}"
 
-LATEST_RELEASE=$(curl -s https://api.github.com/repos/debloper/piosk/releases/latest | jq -r '.tag_name')
-
-if [ -z "$LATEST_RELEASE" ] || [ "$LATEST_RELEASE" = "null" ]; then
-  echo -e "${ERROR}Could not find any releases on the GitHub repository.${RESET}"
-  exit 1
-fi
 
 DOWNLOAD_URL="https://github.com/debloper/piosk/releases/download/$LATEST_RELEASE/$BINARY_NAME.tar.gz"
 echo -e "${INFO}Downloading from: $DOWNLOAD_URL${RESET}"

--- a/www/src/pages/docs.astro
+++ b/www/src/pages/docs.astro
@@ -108,7 +108,6 @@ import Layout from '../layouts/Layout.astro';
           <ol>
             <li>The PiOSK repo is cloned to <code>/opt/piosk</code></li>
             <li>You can change the dashboard port from <code>index.js</code></li>
-            <li>You can change the per-page timeout from <code>scripts/switcher.sh</code></li>
             <li>You can change browser behavior (e.g. no full screen) from <code>scripts/runner.sh</code></li>
             <li>Some changes can be applied without rebooting, but rebooting is simpler</li>
           </ol>
@@ -142,7 +141,7 @@ import Layout from '../layouts/Layout.astro';
             <code>sudo /opt/piosk/scripts/cleanup.sh</code>
           </div>
           <div class="note">
-            <p><strong>Note:</strong> By default PiOSK doesn't uninstall the system packages it installs as dependencies (i.e. <code>git</code>, <code>jq</code>, <code>Node.js</code>, <code>wtype</code>). The reason being, if they're force removed, then other packages (which have been installed since) that may also rely on them - will break.</p>
+            <p><strong>Note:</strong> By default PiOSK doesn't uninstall the system packages it installs as dependencies (i.e. <code>git</code>, <code>jq</code>, <code>wtype</code>). The reason being, if they're force removed, then other packages (which have been installed since) that may also rely on them - will break.</p>
           </div>
         </section>
 
@@ -152,7 +151,7 @@ import Layout from '../layouts/Layout.astro';
           <h3 id="assumptions">2.1 Assumptions</h3>
           <ol start="0">
             <li>You're using a Raspberry Pi (other SBCs may work, not tested)</li>
-            <li>You're using "Raspberry Pi OS with desktop (32bit)" (other distros may work, not tested)</li>
+            <li>You're using "Raspberry Pi OS (64bit)" (This is a mandatory requirement for PiOSK (version 4.0.0 and newer). PiOSK now uses the Deno runtime, which does not provide official binaries for 32-bit ARM systems. This change allows PiOSK to be a standalone executable, simplifying installation by removing the need for a separate Node.js runtime.)</li>
             <li>You've applied proper OS customizations & the Pi is able to access the internet (required for setup)</li>
             <li>You're not using port 80 on the Pi to run some other web server (apart from PiOSK dashboard)</li>
           </ol>
@@ -160,7 +159,6 @@ import Layout from '../layouts/Layout.astro';
           <h3 id="recommendations">2.2 Recommendations</h3>
           <h4>Choose the right device and OS</h4>
           <ul>
-            <li>If your Pi has 4GB or less memory, choose 32bit image</li>
             <li>Raspberry Pi Zeros struggle running Chromium due to low memory</li>
             <li>Raspberry Pi4 or Pi5 (or their compute modules) are ideal for PiOSK</li>
             <li>Apply the necessary customizations (user account, WiFi credentials, SSH access etc)</li>

--- a/www/src/pages/docs.astro
+++ b/www/src/pages/docs.astro
@@ -69,7 +69,7 @@ import Layout from '../layouts/Layout.astro';
         <section id="installation" class="docs-section">
           <h2>1.2 Installation</h2>
           <p>Either open terminal on the Raspberry Pi's desktop environment, or remote login to it; and run the following command:</p>
-          <div class="code-block" data-code="curl -sSL https://raw.githubusercontent.com/debloper/piosk/d586dfa833187df34de8e8345b85c8d27be8bdc9/scripts/setup.sh | sudo bash -">
+          <div class="code-block" data-code="curl -sSL https://raw.githubusercontent.com/debloper/piosk/v4.0.0/scripts/setup.sh | sudo bash -">
             <div class="code-header">
               <span class="code-language">bash</span>
               <button class="copy-button" onclick="copyCode(this)">
@@ -80,7 +80,7 @@ import Layout from '../layouts/Layout.astro';
                 Copy
               </button>
             </div>
-            <code>curl -sSL https://raw.githubusercontent.com/debloper/piosk/main/scripts/setup.sh | sudo bash -</code>
+            <code>curl -sSL https://raw.githubusercontent.com/debloper/piosk/v4.0.0/scripts/setup.sh | sudo bash -</code>
           </div>
           <p>That's it<sup>2</sup>.</p>
           <div class="footnote">


### PR DESCRIPTION
This PR Updates documentation for PiOSK v4.0.0

### Updates:
1. The installation command has been updated to point to version `v4.0.0`
  `curl -sSL https://raw.githubusercontent.com/debloper/piosk/v4.0.0/scripts/setup.sh | sudo bash -`
**Note:** GitHub's raw content URLs require a specific reference, like a version tag (`v4.0.0`) or a branch name (`main`), as they do not support a dynamic `latest` keyword.

2. Removed the warning - "You can change the per-page timeout from `scripts/switcher.sh`"
because from v4 onward, this can be changed directly from the dashboard.

3. Update assumption - Raspberry Pi OS (64bit) is now mandatory requirement 