### PR TITLE
Local js/css scripts

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link href="bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="style.css">
     <title>PiOSK</title>
   </head>
@@ -68,8 +68,8 @@
       <div class="alert alert-danger m-4" role="alert"></div>
     </template>
 
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script src="jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+    <script src="bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
     <script src="script.js"></script>
     <script src="ui.js"></script>

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -94,7 +94,6 @@ esac
 
 echo -e "${DEBUG}Architecture: '$ARCH', Binary: '$BINARY_NAME'${RESET}"
 
-
 DOWNLOAD_URL="https://github.com/debloper/piosk/releases/download/$LATEST_RELEASE/$BINARY_NAME.tar.gz"
 echo -e "${INFO}Downloading from: $DOWNLOAD_URL${RESET}"
 
@@ -106,6 +105,27 @@ fi
 chmod +x "$BINARY_NAME"
 mv "$BINARY_NAME" piosk
 echo -e "${SUCCESS}PiOSK binary downloaded successfully.${RESET}"
+
+# --- JS/CSS Download ---
+
+FILES=(
+  "jquery-3.7.1.min.js|https://code.jquery.com/"
+  "bootstrap.bundle.min.js|https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/"
+  "bootstrap.min.css|https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/"
+)
+
+for entry in "${FILES[@]}"; do
+  FILE="${entry%%|*}"
+  URL="${entry#*|}${FILE}"
+  echo -e "${INFO}Downloading from: $URL${RESET}"
+
+  if ! curl -fL --progress-bar "$URL" -o "$PIOSK_DIR/web/$FILE"; then
+    echo -e "${ERROR}Failed to download $URL.${RESET}"
+    exit 1
+  fi
+done
+
+echo -e "${SUCCESS}external scripts downloaded successfully.${RESET}"
 
 # --- Configuration Setup ---
 echo -e "${INFO}Restoring configurations...${RESET}"


### PR DESCRIPTION
From Discussion:  #113 
I hit a small road block when using PiOSK in an air gaped environment. The js and css scripts (bootstrap.bundle.min.js, bootstrap.min.css, jquery-3.7.1.min.js) don't load. I also can imagine usecases where the Pi are not allowed to load something from outside.

I implemented the downloading of the external scripts within the setup script and the paths in the index.html from the external to local.