### PR TITLE
Restrict astro workflow to run only on www/ changes

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -2,10 +2,10 @@ name: Deploy Astro site to Pages
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
     paths:
-      - "www/**"
-
+      - www/**
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -3,6 +3,8 @@ name: Deploy Astro site to Pages
 on:
   push:
     branches: ["main"]
+    paths:
+      - "www/**"
 
   workflow_dispatch:
 


### PR DESCRIPTION
The astro deployment workflow was previously running on every push to `main`, even when unrelated parts of the repository were modified.

This PR updates the workflow trigger to run only when files inside the `www/` directory change