### PR TITLE
fix:Ensure installs work across releases

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Installation directory
+PIOSK_DIR="/opt/piosk"
+
+# --- ANSI Color Codes ---
+RESET='\033[0m'      # Reset to default
+ERROR='\033[1;31m'   # Bold Red
+SUCCESS='\033[1;32m' # Bold Green
+WARNING='\033[1;33m' # Bold Yellow
+INFO='\033[1;34m'    # Bold Blue
+CALLOUT='\033[1;35m' # Bold Magenta
+DEBUG='\033[1;36m'   # Bold Cyan
+
+# --- Sudo Privilege Check ---
+echo -e "${INFO}Checking superuser privileges...${RESET}"
+if [ "$EUID" -ne 0 ]; then
+  echo -e "${DEBUG}Escalating privileges as superuser...${RESET}"
+
+  sudo "$0" "$@" # Re-execute the script as superuser
+  exit $?  # Exit with the status of the sudo command
+fi
+
+# --- Autologin Configuration ---
+echo -e "${INFO}Configuring autologin...${RESET}"
+if grep -q "autologin" "/etc/systemd/system/getty@tty1.service.d/autologin.conf" 2>/dev/null; then
+  echo -e "${SUCCESS}\tautologin is already enabled!${RESET}."
+else
+  if command -v raspi-config >/dev/null 2>&1; then
+    echo -e "${DEBUG}Enabling autologin using raspi-config...${RESET}"
+    raspi-config nonint do_boot_behaviour B4
+    echo -e "${SUCCESS}\tAutologin has been enabled!${RESET}"
+  else
+    echo -e "${ERROR}Could not enable autologin${RESET}"
+    echo -e "${ERROR}Please configure autologin manually and rerun setup.${RESET}"
+    exit 1
+  fi
+fi
+
+# --- Dependency Installation ---
+echo -e "${INFO}Installing dependencies...${RESET}"
+apt update && apt install -y git jq wtype curl unzip
+
+# --- Repository Context Check ---
+if [ ! -d "$PIOSK_DIR" ]; then
+  echo -e "${ERROR}PiOSK directory not found at ${PIOSK_DIR}.${RESET}"
+  echo -e "${ERROR}Please run this script using the setup.sh loader.${RESET}"
+  exit 1
+fi
+cd "$PIOSK_DIR"
+
+# --- Determine Version ---
+LATEST_RELEASE=$(git describe --tags 2>/dev/null || echo "unknown")
+echo -e "${SUCCESS}Latest release is ${LATEST_RELEASE}.${RESET}"
+
+# --- Binary Download ---
+echo -e "${INFO}Downloading PiOSK binary...${RESET}"
+ARCH=$(uname -m)
+BINARY_NAME=""
+
+case "${ARCH}" in
+  x86_64)
+    BINARY_NAME="piosk-linux-x64"
+    ;;
+  aarch64|arm64)
+    BINARY_NAME="piosk-linux-arm64"
+    ;;
+  *)
+    echo -e "${ERROR}Unsupported architecture: $ARCH${RESET}"
+    echo -e "${ERROR}No pre-compiled binary is available for your system.${RESET}"
+    exit 1
+    ;;
+esac
+
+echo -e "${DEBUG}Architecture: '$ARCH', Binary: '$BINARY_NAME'${RESET}"
+
+DOWNLOAD_URL="https://github.com/debloper/piosk/releases/download/$LATEST_RELEASE/$BINARY_NAME.tar.gz"
+echo -e "${INFO}Downloading from: $DOWNLOAD_URL${RESET}"
+
+# Ensure dashboard directory exists before extraction
+mkdir -p dashboard
+if ! curl -fL --progress-bar "$DOWNLOAD_URL" | tar -xz -C dashboard/; then
+  echo -e "${ERROR}Failed to download or extract the binary.${RESET}"
+  exit 1
+fi
+
+chmod +x "dashboard/$BINARY_NAME"
+mv "dashboard/$BINARY_NAME" "dashboard/piosk"
+echo -e "${SUCCESS}PiOSK binary downloaded successfully.${RESET}"
+
+# --- Configuration Setup ---
+echo -e "${INFO}Restoring configurations...${RESET}"
+if [ ! -f "$PIOSK_DIR/config.json" ]; then
+    if [ -f /opt/piosk.config.bak ]; then
+        echo -e "${DEBUG}Restoring backed-up configuration...${RESET}"
+        mv /opt/piosk.config.bak "$PIOSK_DIR/config.json"
+    else
+        echo -e "${DEBUG}Creating default configuration from sample...${RESET}"
+        mv config.json.sample config.json
+    fi
+fi
+
+# --- Service Installation ---
+echo -e "${INFO}Installing PiOSK services...${RESET}"
+PI_USER="$SUDO_USER"
+PI_SUID=$(id -u "$SUDO_USER")
+PI_HOME=$(eval echo ~"$SUDO_USER")
+
+sed -e "s|PI_HOME|$PI_HOME|g" \
+    -e "s|PI_SUID|$PI_SUID|g" \
+    -e "s|PI_USER|$PI_USER|g" \
+    "$PIOSK_DIR/services/piosk-runner.template" > "/etc/systemd/system/piosk-runner.service"
+
+sed -e "s|PI_HOME|$PI_HOME|g" \
+    -e "s|PI_SUID|$PI_SUID|g" \
+    -e "s|PI_USER|$PI_USER|g" \
+    "$PIOSK_DIR/services/piosk-switcher.template" > "/etc/systemd/system/piosk-switcher.service"
+
+cp "$PIOSK_DIR/services/piosk-dashboard.template" /etc/systemd/system/piosk-dashboard.service
+
+# --- Finalizing Setup ---
+echo -e "${INFO}Reloading systemd daemons...${RESET}"
+systemctl daemon-reload
+
+echo -e "${INFO}Enabling PiOSK daemons...${RESET}"
+systemctl enable piosk-runner
+systemctl enable piosk-switcher
+systemctl enable piosk-dashboard
+
+echo -e "${INFO}Starting PiOSK daemons...${RESET}"
+# The runner and switcher services are meant to be started after reboot
+# systemctl start piosk-runner
+# systemctl start piosk-switcher
+systemctl start piosk-dashboard
+
+echo -e "${CALLOUT}\nPiOSK is now installed.${RESET}"
+echo -e "Visit either of these links to access PiOSK dashboard:"
+echo -e "\t- ${INFO}\033[0;32mhttp://$(hostname)/${RESET} or,"
+echo -e "\t- ${INFO}http://$(hostname -I | cut -d " " -f1)/${RESET}"
+echo -e "Use the dashboard to configure URLs, then apply changes to reboot."
+echo -e "${WARNING}\033[0;31mThe kiosk mode will launch on next startup.${RESET}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,160 +1,63 @@
 #!/bin/bash
-
-# Exit immediately if a command exits with a non-zero status
 set -e
 
-# Installation directory
-PIOSK_DIR="/opt/piosk"
+# --- ANSI Colors ---
+RESET='\033[0m'
+INFO='\033[1;34m'
+SUCCESS='\033[1;32m'
+ERROR='\033[1;31m'
+DEBUG='\033[1;36m'
 
-# --- ANSI Color Codes ---
-RESET='\033[0m'      # Reset to default
-ERROR='\033[1;31m'   # Bold Red
-SUCCESS='\033[1;32m' # Bold Green
-WARNING='\033[1;33m' # Bold Yellow
-INFO='\033[1;34m'    # Bold Blue
-CALLOUT='\033[1;35m' # Bold Magenta
-DEBUG='\033[1;36m'   # Bold Cyan
+# --- Constants ---
+REPO_OWNER="debloper"
+REPO_NAME="piosk"
+REPO_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}.git"
+INSTALL_DIR="/opt/${REPO_NAME}"
+CONFIG_FILE="${INSTALL_DIR}/config.json"
+CONFIG_BACKUP="/opt/piosk.config.bak"
 
-# --- Sudo Privilege Check ---
-echo -e "${INFO}Checking superuser privileges...${RESET}"
-if [ "$EUID" -ne 0 ]; then
-  echo -e "${DEBUG}Escalating privileges as superuser...${RESET}"
+echo -e "${INFO}Fetching latest release tag...${RESET}"
+LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" | jq -r '.tag_name')
 
-  sudo "$0" "$@" # Re-execute the script as superuser
-  exit $?  # Exit with the status of the sudo command
+if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+  echo -e "${ERROR}❌ Failed to fetch latest release tag from GitHub.${RESET}"
+  exit 1
+fi
+echo -e "${SUCCESS}✅ Latest release detected: ${LATEST_TAG}${RESET}"
+
+# --- Ensure git is available ---
+if ! command -v git >/dev/null 2>&1; then
+  echo -e "${INFO}Installing git...${RESET}"
+  apt update -qq && apt install -y git >/dev/null
 fi
 
-# --- Autologin Configuration ---
-echo -e "${INFO}Configuring autologin...${RESET}"
-if grep -q "autologin" "/etc/systemd/system/getty@tty1.service.d/autologin.conf" 2>/dev/null; then
-  echo -e "${SUCCESS}\tautologin is already enabled!${RESET}."
+# --- Backup existing config if present ---
+if [ -f "$CONFIG_FILE" ]; then
+  echo -e "${DEBUG}Backing up existing configuration...${RESET}"
+  cp "$CONFIG_FILE" "$CONFIG_BACKUP"
+fi
+
+# --- Clone or update repo ---
+if [ -d "$INSTALL_DIR" ]; then
+  echo -e "${DEBUG}Removing old ${INSTALL_DIR}...${RESET}"
+  rm -rf "$INSTALL_DIR"
+fi
+
+echo -e "${INFO}Cloning ${REPO_URL}@${LATEST_TAG}...${RESET}"
+git clone --depth 1 --branch "$LATEST_TAG" "$REPO_URL" "$INSTALL_DIR"
+
+# --- Restore configuration if backup exists ---
+if [ -f "$CONFIG_BACKUP" ]; then
+  echo -e "${DEBUG}Restoring previous configuration...${RESET}"
+  mv "$CONFIG_BACKUP" "$CONFIG_FILE"
+fi
+
+# --- Run installer from tag ---
+cd "$INSTALL_DIR/scripts"
+echo -e "${INFO}Running install.sh from ${LATEST_TAG}...${RESET}"
+if bash install.sh "$@"; then
+  echo -e "${SUCCESS}✅ PiOSK installed successfully (tag ${LATEST_TAG}).${RESET}"
 else
-  if command -v raspi-config >/dev/null 2>&1; then
-    echo -e "${DEBUG}Enabling autologin using raspi-config...${RESET}"
-    raspi-config nonint do_boot_behaviour B4
-    echo -e "${SUCCESS}\tAutologin has been enabled!${RESET}"
-  else
-    echo -e "${ERROR}Could not enable autologin${RESET}"
-    echo -e "${ERROR}Please configure autologin manually and rerun setup.${RESET}"
-    exit 1
-  fi
-fi
-
-# --- Dependency Installation ---
-echo -e "${INFO}Installing dependencies...${RESET}"
-apt update && apt install -y git jq wtype curl unzip
-
-# --- Get Latest Release Info ---
-# Fetched early to be used for both git checkout and binary download.
-echo -e "${INFO}Finding latest stable release...${RESET}"
-LATEST_RELEASE=$(curl -s https://api.github.com/repos/debloper/piosk/releases/latest | jq -r '.tag_name')
-
-if [ -z "$LATEST_RELEASE" ] || [ "$LATEST_RELEASE" = "null" ]; then
-  echo -e "${ERROR}Could not find any releases on the GitHub repository.${RESET}"
+  echo -e "${ERROR}❌ Installation failed for tag ${LATEST_TAG}.${RESET}"
   exit 1
 fi
-echo -e "${SUCCESS}Latest release is ${LATEST_RELEASE}.${RESET}"
-
-
-# --- Repo Cloning and Checkout ---
-echo -e "${INFO}Cloning repository...${RESET}"
-
-# Before deleting the directory, check if a config file exists and back it up.
-if [ -f "$PIOSK_DIR/config.json" ]; then
-    echo -e "${DEBUG}Found existing installation. Backing up config.json...${RESET}"
-    cp "$PIOSK_DIR/config.json" /opt/piosk.config.bak
-fi
-
-rm -rf "$PIOSK_DIR"
-git clone https://github.com/debloper/piosk.git "$PIOSK_DIR"
-cd "$PIOSK_DIR"
-
-# Checkout the latest stable release to ensure code matches the binary
-echo -e "${INFO}Checking out release ${LATEST_RELEASE}...${RESET}"
-git checkout "$LATEST_RELEASE"
-
-# --- Binary Download ---
-echo -e "${INFO}Downloading PiOSK binary...${RESET}"
-ARCH=$(uname -m)
-BINARY_NAME=""
-
-case "${ARCH}" in
-  x86_64)
-    BINARY_NAME="piosk-linux-x64"
-    ;;
-  aarch64|arm64)
-    BINARY_NAME="piosk-linux-arm64"
-    ;;
-  *)
-    echo -e "${ERROR}Unsupported architecture: $ARCH${RESET}"
-    echo -e "${ERROR}No pre-compiled binary is available for your system.${RESET}"
-    exit 1
-    ;;
-esac
-
-echo -e "${DEBUG}Architecture: '$ARCH', Binary: '$BINARY_NAME'${RESET}"
-
-
-DOWNLOAD_URL="https://github.com/debloper/piosk/releases/download/$LATEST_RELEASE/$BINARY_NAME.tar.gz"
-echo -e "${INFO}Downloading from: $DOWNLOAD_URL${RESET}"
-
-if ! curl -fL --progress-bar "$DOWNLOAD_URL" | tar -xz -C dashboard/; then
-  echo -e "${ERROR}Failed to download or extract the binary.${RESET}"
-  exit 1
-fi
-
-chmod +x "dashboard/$BINARY_NAME"
-mv "dashboard/$BINARY_NAME" "dashboard/piosk"
-echo -e "${SUCCESS}PiOSK binary downloaded successfully.${RESET}"
-
-# --- Configuration Setup ---
-echo -e "${INFO}Restoring configurations...${RESET}"
-if [ ! -f /opt/piosk/config.json ]; then
-    if [ -f /opt/piosk.config.bak ]; then
-        echo -e "${DEBUG}Restoring backed-up configuration...${RESET}"
-        mv /opt/piosk.config.bak /opt/piosk/config.json
-    else
-        echo -e "${DEBUG}Creating default configuration from sample...${RESET}"
-        mv config.json.sample config.json
-    fi
-fi
-
-# --- Service Installation ---
-echo -e "${INFO}Installing PiOSK services...${RESET}"
-PI_USER="$SUDO_USER"
-PI_SUID=$(id -u "$SUDO_USER")
-PI_HOME=$(eval echo ~"$SUDO_USER")
-
-sed -e "s|PI_HOME|$PI_HOME|g" \
-    -e "s|PI_SUID|$PI_SUID|g" \
-    -e "s|PI_USER|$PI_USER|g" \
-    "$PIOSK_DIR/services/piosk-runner.template" > "/etc/systemd/system/piosk-runner.service"
-
-sed -e "s|PI_HOME|$PI_HOME|g" \
-    -e "s|PI_SUID|$PI_SUID|g" \
-    -e "s|PI_USER|$PI_USER|g" \
-    "$PIOSK_DIR/services/piosk-switcher.template" > "/etc/systemd/system/piosk-switcher.service"
-
-cp "$PIOSK_DIR/services/piosk-dashboard.template" /etc/systemd/system/piosk-dashboard.service
-
-# --- Finalizing Setup ---
-echo -e "${INFO}Reloading systemd daemons...${RESET}"
-systemctl daemon-reload
-
-echo -e "${INFO}Enabling PiOSK daemons...${RESET}"
-systemctl enable piosk-runner
-systemctl enable piosk-switcher
-systemctl enable piosk-dashboard
-
-echo -e "${INFO}Starting PiOSK daemons...${RESET}"
-# The runner and switcher services are meant to be started after reboot
-# systemctl start piosk-runner
-# systemctl start piosk-switcher
-systemctl start piosk-dashboard
-
-echo -e "${CALLOUT}\nPiOSK is now installed.${RESET}"
-echo -e "Visit either of these links to access PiOSK dashboard:"
-echo -e "\t- ${INFO}\033[0;32mhttp://$(hostname)/${RESET} or,"
-echo -e "\t- ${INFO}http://$(hostname -I | cut -d " " -f1)/${RESET}"
-echo -e "Use the dashboard to configure URLs, then apply changes to reboot."
-echo -e "${WARNING}\033[0;31mThe kiosk mode will launch on next startup.${RESET}"


### PR DESCRIPTION
Renamed setup.sh to install.sh so that your README.md and published 'how to install' details dont change.  Users still use `curl -sSL https://raw.githubusercontent.com/debloper/piosk/v4.0.0/scripts/setup.sh | sudo bash -`
to install.

setup.sh _only_ looks after cloning the latest tagged release before handing over to your (originally `setup.sh`) `install.sh`.  I updated install.sh to not do any of the cloning work (as the _new_ `setup.sh` does that.

No actually tested on my Pi yet.  I'll do that when I get home (on teabreak here at work :-) )