### PR TITLE
Fix - v5 installation

### DIFF
--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -17,7 +17,7 @@ msg "$SUCCESS" "Target user identified as '$PI_USER'."
 # 2. INSTALL RUNTIME DEPENDENCIES
 msg "$INFO" "Installing runtime dependencies (wtype, chromium)..."
 apt-get update
-apt-get install -y wtype chromium
+apt-get install -y wtype chromium jq
 
 # 3. INSTALL BINARY
 msg "$INFO" "Installing PiOSK binary..."

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -21,7 +21,7 @@ apt-get install -y wtype chromium
 
 # 3. INSTALL BINARY
 msg "$INFO" "Installing PiOSK binary..."
-BINARY_FILE=$(find "$PIOSK_INSTALL_DIR/dashboard" -maxdepth 1 -type f -name 'piosk-v*')
+BINARY_FILE=$(find "$PIOSK_INSTALL_DIR/dashboard" -maxdepth 1 -type f -name 'piosk-linux-*')
 if [ -z "$BINARY_FILE" ]; then
     msg "$ERROR" "PiOSK binary not found. Package is corrupt."
     exit 1


### PR DESCRIPTION
Two Updates in `install.sh`
1. correct binary filename pattern to match new binary naming convention
2. add `jq` to dependencies in install dependencies step in `install.sh`
