### PR TITLE
Refactor(build): Simplify binary naming in build and install process

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,7 +35,7 @@ jobs:
             --allow-run \
             --allow-env \
             --target ${{ matrix.arch }}-unknown-linux-gnu \
-            --output piosk-linux-${{ matrix.arch }} \
+            --output piosk \
             dashboard/index.ts
 
       - name: Assemble Release Package
@@ -47,7 +47,7 @@ jobs:
           cp -r dashboard/ scripts/ services/ config.json.sample staging/
 
           # 3. Move the compiled binary into the 'dashboard' subdirectory inside staging.
-          mv piosk-linux-${{ matrix.arch }} staging/dashboard/
+          mv piosk staging/dashboard/
 
           # 4. Create the final tarball from the contents of the staging directory.
           #    The -C flag ensures the paths inside the tarball are clean (no leading 'staging/').

--- a/scripts/setup/install.sh
+++ b/scripts/setup/install.sh
@@ -21,14 +21,13 @@ apt-get install -y wtype chromium jq
 
 # 3. INSTALL BINARY
 msg "$INFO" "Installing PiOSK binary..."
-BINARY_FILE=$(find "$PIOSK_INSTALL_DIR/dashboard" -maxdepth 1 -type f -name 'piosk-linux-*')
-if [ -z "$BINARY_FILE" ]; then
+BINARY_FILE="$PIOSK_INSTALL_DIR/dashboard/piosk"
+if [ ! -f "$BINARY_FILE" ]; then
     msg "$ERROR" "PiOSK binary not found. Package is corrupt."
     exit 1
 fi
 chmod +x "$BINARY_FILE"
-mv "$BINARY_FILE" "$PIOSK_INSTALL_DIR/dashboard/piosk" # Rename the versioned binary to 'piosk' inside /opt/piosk
-msg "$SUCCESS" "Binary prepared at $PIOSK_INSTALL_DIR/dashboard/piosk"
+msg "$SUCCESS" "Binary prepared at $BINARY_FILE"
 
 # 4. SETUP CONFIGURATION
 msg "$INFO" "Setting up configuration file..."


### PR DESCRIPTION
Previously, the build workflow would compile the binary to `piosk-linux-[arch]`, and the install script would then have to rename it to `piosk`

This PR simplifies it by unifying the binary name in compilation and installation.