### PR TITLE
feat: add start/stop controls on the dashboard

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -17,6 +17,7 @@
           <button id="add-url" type="button" class="btn btn-secondary">ADD</button>
           <button id="execute" type="button" class="btn btn-danger">APPLY <span class="align-text-bottom">⏻</span></button>
         </div>
+        <button id="toggle-kiosk" type="button" class="btn btn-lg mx-2" style="min-width: 100px;">...</button> 
       </div>
     </nav>
 

--- a/dashboard/index.ts
+++ b/dashboard/index.ts
@@ -136,14 +136,14 @@ async function handler(req: Request): Promise<Response> {
     }
   }
 
-  if (url.pathname === "/status" && req.method === "GET") {
+  if (url.pathname === "/services/status" && req.method === "GET") {
     const isRunning = await getServiceStatus();
     return new Response(JSON.stringify({ running: isRunning }), {
       headers: { "Content-Type": "application/json" }
     });
   }
 
-  if (url.pathname === "/start" && req.method === "POST") {
+  if (url.pathname === "/services/start" && req.method === "POST") {
     try {
       await invokeService("start");
       return new Response("Kiosk started.", { status: 200 });
@@ -153,7 +153,7 @@ async function handler(req: Request): Promise<Response> {
     }
   }
 
-  if (url.pathname === "/stop" && req.method === "POST") {
+  if (url.pathname === "/services/stop" && req.method === "POST") {
     try {
       await invokeService("stop");
       return new Response("Kiosk stopped successfully.", { status: 200 });

--- a/dashboard/index.ts
+++ b/dashboard/index.ts
@@ -121,13 +121,13 @@ async function handler(req: Request): Promise<Response> {
         
         await writeConfig(JSON.stringify(JSON.parse(configData), null, "  "));
         
-        // Reboot system
+        // Restart services
         try {
           await invokeService("restart");
-          return new Response("New config applied; rebooting for changes to take effect...", { status: 200 });
-        } catch (rebootError) {
-          console.error("Reboot error:", rebootError);
-          return new Response("Could not reboot to apply config. Retry or reboot manually.", { status: 500 });
+          return new Response("New config applied; restarting services for changes to take effect...", { status: 200 });
+        } catch (restartError) {
+          console.error("Restart error:", restartError);
+          return new Response("Could not restart services to apply config. Retry manually.", { status: 500 });
         }
       } catch (error) {
         console.error("Error saving config:", error);

--- a/dashboard/script.js
+++ b/dashboard/script.js
@@ -35,9 +35,57 @@ let piosk = {
     }
   },
 
+  // Helper to toggle button loading state
+  toggleLoading($btn, isLoading, loadingText = "Processing...") {
+    if (isLoading) {
+      $btn.data('original-html', $btn.html());
+      $btn.prop('disabled', true);
+      $btn.html(`<span class="spinner-border spinner-border-sm" aria-hidden="true"></span> ${loadingText}`);
+    } else {
+      $btn.prop('disabled', false);
+      $btn.html($btn.data('original-html')); // Restore original look
+    }
+  },
+
+  updatePowerBtn(isRunning) {
+    const $btn = $('#toggle-kiosk');
+    
+    if ($btn.prop('disabled') && $btn.text().includes('...')) return;
+
+    $btn.prop('disabled', false);
+
+    if (isRunning) {
+        $btn.removeClass('btn-success btn-secondary').addClass('btn-warning');
+        $btn.html('STOP'); 
+        $btn.attr('data-action', 'stop'); 
+    } else {
+        $btn.removeClass('btn-warning btn-secondary').addClass('btn-success');
+        $btn.html('START');
+        $btn.attr('data-action', 'start');
+    }
+  },
+
+  checkStatus() {
+    $.getJSON('/status')
+      .done((data) => {
+        piosk.updatePowerBtn(data.running);
+      })
+      .fail(() => {
+        if (!$('#toggle-kiosk').prop('disabled')) {
+            $('#toggle-kiosk').addClass('btn-secondary').prop('disabled', true).text('Offline');
+        }
+      });
+  },
+
   showStatus(xhr) {
     let tmpErr = $('#template-err').contents().clone();
-    tmpErr.html(xhr.responseText);
+    let msg = xhr.responseText || xhr.message || "Unknown error";
+
+    if (xhr.status === 200) {
+        tmpErr.removeClass('alert-danger').addClass('alert-success');
+    }
+
+    tmpErr.html(msg);
     $('#urls').append(tmpErr);
     setTimeout(_ => { $('.alert-danger').remove() }, 5000);
   }
@@ -48,6 +96,9 @@ $(document).ready(() => {
     .done(piosk.renderPage)
     .fail(piosk.showStatus);
 
+  piosk.checkStatus();
+  setInterval(piosk.checkStatus, 5000);
+
   $('#add-url').on('click', piosk.addNewUrl);
   $('#new-url').on('keyup', (e) => { if (e.key === 'Enter') piosk.addNewUrl(); });
 
@@ -56,7 +107,10 @@ $(document).ready(() => {
   });
 
   // MODIFIED: The #execute handler now saves all settings correctly
-  $('#execute').on('click', (e) => {
+  $('#execute').on('click', function(e) {
+    const $btn = $(this);
+    piosk.toggleLoading($btn, true, "Applying...");
+
     let config = {};
     config.urls = [];
     $('li.list-group-item').each((index, item) => {
@@ -77,9 +131,38 @@ $(document).ready(() => {
       type: 'POST',
       data: JSON.stringify(config),
       contentType: "application/json; charset=utf-8",
-      dataType: "json",
-      success: piosk.showStatus,
-      error: piosk.showStatus
+      success: (data) => {
+        piosk.showStatus({ status: 200, responseText: data });
+      },
+      error: piosk.showStatus,
+      complete: () => {
+          piosk.toggleLoading($btn, false);
+      }
+    });
+  });
+
+  $('#toggle-kiosk').on('click', function() {
+    const $btn = $(this);
+    const action = $btn.attr('data-action'); 
+    
+    if(action === 'stop' && !confirm("Stop the Kiosk display?")) return;
+
+    const loadText = action === 'start' ? "Starting..." : "Stopping...";
+    piosk.toggleLoading($btn, true, loadText);
+
+    $.ajax({
+      url: '/' + action, 
+      type: 'POST',
+      success: (data) => {
+          piosk.showStatus({ status: 200, responseText: data });
+          setTimeout(piosk.checkStatus, 1000); 
+      },
+      error: (xhr) => {
+          piosk.showStatus(xhr);
+      },
+      complete: () => {
+           setTimeout(() => { piosk.toggleLoading($btn, false); }, 500);
+      }
     });
   });
 });

--- a/dashboard/script.js
+++ b/dashboard/script.js
@@ -156,9 +156,7 @@ $(document).ready(() => {
       success: (data) => {
           piosk.showStatus({ status: 200, responseText: data });
       },
-      error: (xhr) => {
-          piosk.showStatus(xhr);
-      },
+      error: piosk.showStatus,
       complete: () => {
            setTimeout(() => { piosk.toggleLoading($btn, false); }, 500);
       }

--- a/dashboard/script.js
+++ b/dashboard/script.js
@@ -155,7 +155,6 @@ $(document).ready(() => {
       type: 'POST',
       success: (data) => {
           piosk.showStatus({ status: 200, responseText: data });
-          setTimeout(piosk.checkStatus, 1000); 
       },
       error: (xhr) => {
           piosk.showStatus(xhr);

--- a/dashboard/script.js
+++ b/dashboard/script.js
@@ -66,7 +66,7 @@ let piosk = {
   },
 
   checkStatus() {
-    $.getJSON('/status')
+    $.getJSON('/services/status')
       .done((data) => {
         piosk.updatePowerBtn(data.running);
       })
@@ -151,7 +151,7 @@ $(document).ready(() => {
     piosk.toggleLoading($btn, true, loadText);
 
     $.ajax({
-      url: '/' + action, 
+      url: '/services/' + action, 
       type: 'POST',
       success: (data) => {
           piosk.showStatus({ status: 200, responseText: data });


### PR DESCRIPTION
- Implemented 5s polling interval to sync dashboard with systemd service status
- Added remote Start/Stop toggle button to navbar
- Added loading spinners to buttons for better visual feedback during async ops
- Updated `index.ts` backend script to handle /start, /stop, and /status endpoints via systemctl
- [x] Tested all changes on rPi 5, latest OS (trixie)