### PR TITLE
fix the success message alert message bug

### DIFF
--- a/dashboard/script.js
+++ b/dashboard/script.js
@@ -87,7 +87,7 @@ let piosk = {
 
     tmpErr.html(msg);
     $('#urls').append(tmpErr);
-    setTimeout(_ => { $('.alert-danger').remove() }, 5000);
+    setTimeout(_ => { tmpErr.remove() }, 5000);
   }
 };
 


### PR DESCRIPTION
Bug: 
success alert message is not getting removed from the dashboard after applying changes.

Cause:
In `showStatus` function, we check if the request was successful (status 200). If it is, we remove the `alert-danger` class and add `alert-success`.
However, the cleanup timer specifically looks for `.alert-danger` to remove it. Because the successful "Apply" message is now an `.alert-success`, the timer ignores it, and the message stays on screen.

Fix:
By using `tmpErr.remove()`, we remove that specific alert instance regardless of whether it is an error(red) or a success(green) message.