### PR TITLE
Fix: Allow `cycles` parameter to accept `0` to disable auto-switching

### DIFF
--- a/dashboard/script.js
+++ b/dashboard/script.js
@@ -18,7 +18,7 @@ let xiosk = {
     if (duration) {
       $(tmpUrl).find('.duration-input').val(duration);
     }
-    if (cycles) {
+    if (cycles != null) {
       $(tmpUrl).find('.cycles-input').val(cycles);
     }
 

--- a/dashboard/script.js
+++ b/dashboard/script.js
@@ -117,7 +117,7 @@ $(document).ready(() => {
       // Now collecting all data: url, duration, and cycles
       const url = $(item).find('a').attr('href');
       const duration = parseInt($(item).find('.duration-input').val()) || 10;
-      const cycles = parseInt($(item).find('.cycles-input').val()) || 10;
+      const cycles = parseInt($(item).find('.cycles-input').val()) ?? 10;
 
       config.urls.push({
         url: url,


### PR DESCRIPTION
## Fix: Allow `cycles` parameter to accept `0` to disable auto-switching

### Problem
The dashboard frontend currently parses the `cycles` input value using:
```javascript
parseInt($(item).find('.cycles-input').val()) || 10
```

This causes `0` to be treated as falsy, defaulting to `10` instead of being accepted as a valid value.

### Solution
Use the nullish coalescing operator to properly handle `0`:
```javascript
parseInt($(item).find('.cycles-input').val()) ?? 10
```


### Backend Compatibility
The switcher script already supports `0` to skip refreshing:
```shell
# Only run refresh logic if cycle_target is greater than 0
if [ "$cycle_target" -gt 0 ]; then
```

### Use Case
When displaying static dashboards (e.g., Grafana), disabling the xiosk-switcher service gets overridden on configuration updates. Setting `cycles=0` provides a cleaner way to disable auto-switching without stopping the service.

---
Related to #63